### PR TITLE
Add reel optimizer and evaluation tooling

### DIFF
--- a/GameConfig.h
+++ b/GameConfig.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <unordered_map>
 #include <mutex>
+#include <iomanip>
 #include "Symbols.h"
 #include "PrizeDistribution.h"
 
@@ -197,6 +198,57 @@ public:
         }
         return prizeDists;
     }
+
+    nlohmann::json reelSetToJson(const ReelSet& reelSet, const std::string& name = "") const {
+        nlohmann::json node;
+        if (!name.empty()) {
+            node["name"] = name;
+        }
+        node["mask"] = reelSet.getMask();
+        nlohmann::json reelsJson = nlohmann::json::array();
+        for (size_t i = 0; i < reelSet.reels.size(); ++i) {
+            nlohmann::json reelNode;
+            reelNode["name"] = "Reel" + std::to_string(i + 1);
+            reelNode["symbols"] = reelSet.reels[i].symbols;
+            if (!reelSet.reels[i].weights.empty()) {
+                reelNode["weights"] = reelSet.reels[i].weights;
+            }
+            reelsJson.push_back(reelNode);
+        }
+        node["reels"] = reelsJson;
+        return node;
+    }
+
+    void writeReelSetToFile(const ReelSet& reelSet, const std::string& path, const std::string& name = "") const {
+        nlohmann::json data = reelSetToJson(reelSet, name);
+        std::ofstream ofs(path);
+        if (!ofs.is_open()) {
+            throw std::runtime_error("Failed to open " + path);
+        }
+        ofs << std::setw(2) << data;
+    }
+
+    ReelSet readReelSetFromFile(const std::string& path) const {
+        std::ifstream ifs(path);
+        if (!ifs.is_open()) {
+            throw std::runtime_error("Failed to open " + path);
+        }
+        nlohmann::json data;
+        ifs >> data;
+        std::vector<Reel> reels;
+        for (const auto& reelNode : data["reels"]) {
+            std::vector<std::string> symbols = reelNode["symbols"].get<std::vector<std::string>>();
+            std::vector<int> weights;
+            if (reelNode.contains("weights")) {
+                weights = reelNode["weights"].get<std::vector<int>>();
+            }
+            reels.emplace_back(symbols, weights);
+        }
+        std::string mask = data.contains("mask") ? data["mask"].get<std::string>() : "";
+        ReelSet reelSet(reels, mask);
+        return reelSet;
+    }
+
 
 
 

--- a/GameInstance.cpp
+++ b/GameInstance.cpp
@@ -1,0 +1,147 @@
+#include "GameInstance.h"
+#include "RandomUtils.h"
+#include "RandomLogGenerator.h"
+#include <algorithm>
+#include <numeric>
+#include <unordered_map>
+
+extern LogMode logMode;
+
+namespace {
+        void restoreReelSets(std::unordered_map<std::string, ReelSet>& target,
+                const std::vector<std::pair<std::string, ReelSet>>& originals) {
+                for (const auto& entry : originals) {
+                        target[entry.first] = entry.second;
+                }
+        }
+}
+
+void GameInstance::setActiveBaseReelSet(const ReelSet& rs) {
+        if (allReelSets.find("base") != allReelSets.end()) {
+                allReelSets["base"] = rs;
+        }
+        if (allReelSets.find("baseHigh") != allReelSets.end()) {
+                allReelSets["baseHigh"] = rs;
+        }
+        if (allReelSets.find("baseLow") != allReelSets.end()) {
+                allReelSets["baseLow"] = rs;
+        }
+        baseReelSet = rs;
+}
+
+EvalMetrics GameInstance::evaluateReelSet(const ReelSet& rs, uint64_t spins, uint64_t seed) {
+        EvalMetrics metrics;
+        metrics.spins = spins;
+        if (spins == 0) {
+                return metrics;
+        }
+
+        std::vector<std::pair<std::string, ReelSet>> replaced;
+        auto replaceIfExists = [&](const std::string& key) {
+                auto it = allReelSets.find(key);
+                if (it != allReelSets.end()) {
+                        replaced.emplace_back(key, it->second);
+                        it->second = rs;
+                }
+        };
+
+        replaceIfExists("base");
+        replaceIfExists("baseHigh");
+        replaceIfExists("baseLow");
+        baseReelSet = rs;
+
+        auto previousState = getThreadRngState();
+        seedThreadRng(seed);
+
+        LogMode previousMode = logMode;
+        logMode = NO_LOGGING;
+
+        uint64_t baseHits = 0;
+        uint64_t tumbleSum = 0;
+        double totalPay = 0.0;
+
+        boostPDVec.resize(boostWeights.size());
+        for (size_t i = 0; i < boostWeights.size(); ++i) {
+                boostPDVec[i] = PrizeDistribution<int>("BS_" + std::to_string(i + 1), std::vector<int>{0, 1}, boostWeights[i]);
+        }
+
+        for (uint64_t spin = 0; spin < spins; ++spin) {
+                int globalMult = 1;
+                RandomLogGenerator::startRound();
+
+                std::vector<double> pays(payHeaders.size(), 0.0);
+                std::vector<int> reelHeights(numReels);
+                for (int r = 0; r < numReels; ++r) {
+                        reelHeights[r] = reelHeightPD[r].getRandomPrize();
+                }
+                screen.resize(reelHeights);
+
+                auto overIt = allReelSets.find("over");
+                if (overIt != allReelSets.end()) {
+                        overReelSet = overIt->second;
+                        overReelSet.spinReels();
+                }
+                auto underIt = allReelSets.find("under");
+                if (underIt != allReelSets.end()) {
+                        underReelSet = underIt->second;
+                        underReelSet.spinReels();
+                }
+
+                int reelID = 1;
+                ReelSet activeReels;
+                if (reelID == 0 && allReelSets.find("baseLow") != allReelSets.end()) {
+                        activeReels = allReelSets["baseLow"];
+                }
+                else if (allReelSets.find("baseHigh") != allReelSets.end()) {
+                        activeReels = allReelSets["baseHigh"];
+                }
+                else if (allReelSets.find("base") != allReelSets.end()) {
+                        activeReels = allReelSets["base"];
+                }
+                else {
+                        activeReels = rs;
+                }
+
+                activeReels.spinReels();
+
+                boostVecOver.clear();
+                boostVecUnder.clear();
+                for (size_t b = 0; b < boostWeights.size(); ++b) {
+                        boostVecOver.push_back(boostPDVec[b].getRandomPrize());
+                        boostVecUnder.push_back(boostPDVec[b].getRandomPrize());
+                }
+
+                screen.generateScreen(activeReels);
+                screen.addSideSymbols(true, overReelSet, boostVecOver);
+                screen.addSideSymbols(false, underReelSet, boostVecUnder);
+
+                int tumbleCount = 0;
+                std::vector<double> baseVector = handleCascades(screen, activeReels, activeReels, false, true, globalMult, &tumbleCount);
+
+                if (baseVector[0] > 0) {
+                        ++baseHits;
+                        tumbleSum += static_cast<uint64_t>(tumbleCount);
+                }
+
+                pays[BASE] += baseVector[0];
+                pays[TUMBLE] += baseVector[1];
+
+                RandomLogGenerator::endRound();
+
+                pays[TOTAL] = std::accumulate(pays.begin(), pays.end() - 2, 0.0);
+                totalPay += pays[TOTAL];
+        }
+
+        metrics.baseHitRate = static_cast<double>(baseHits) / static_cast<double>(spins);
+        metrics.avgTumblesPerHit = baseHits ? static_cast<double>(tumbleSum) / static_cast<double>(baseHits) : 0.0;
+        metrics.rtp = spins ? totalPay / (static_cast<double>(spins) * cost) : 0.0;
+
+        logMode = previousMode;
+        setThreadRngState(previousState);
+        restoreReelSets(allReelSets, replaced);
+        if (!replaced.empty()) {
+                baseReelSet = replaced.front().second;
+        }
+
+        return metrics;
+}

--- a/GameInstance.h
+++ b/GameInstance.h
@@ -2,6 +2,14 @@
 #include "GameConfig.h"
 #include "Stats.h"
 #include "Screen.h"
+#include <cstdint>
+
+struct EvalMetrics {
+        double baseHitRate = 0.0;
+        double avgTumblesPerHit = 0.0;
+        double rtp = 0.0;
+        uint64_t spins = 0;
+};
 
 class GameInstance {
 
@@ -71,18 +79,23 @@ private:
 
 public:
 
-	explicit GameInstance(std::shared_ptr<GameConfig> config, SymbolStructure& symbolStructure, Stats& stats)
-		: config(config), symbolStructure(symbolStructure), stats(stats),
-		spinCount(0) {
-		initializeGame();
-	}
+        explicit GameInstance(std::shared_ptr<GameConfig> config, SymbolStructure& symbolStructure, Stats& stats)
+                : config(config), symbolStructure(symbolStructure), stats(stats),
+                spinCount(0) {
+                initializeGame();
+        }
 
 
-	// Method to simulate a single spin and return the result
-	double simulateSingleSpin() {
-		playBaseGame(1);  // Simulate one spin
-		double lastSpinPayout = stats.getLastSpinPayout();  // Retrieve payout from the last spin
-		return lastSpinPayout - cost;  // Return net gain/loss (payout minus cost of one spin)
+        void setActiveBaseReelSet(const ReelSet& rs);
+
+        EvalMetrics evaluateReelSet(const ReelSet& rs, uint64_t spins, uint64_t seed);
+
+
+        // Method to simulate a single spin and return the result
+        double simulateSingleSpin() {
+                playBaseGame(1);  // Simulate one spin
+                double lastSpinPayout = stats.getLastSpinPayout();  // Retrieve payout from the last spin
+                return lastSpinPayout - cost;  // Return net gain/loss (payout minus cost of one spin)
 	}
 
 
@@ -250,7 +263,7 @@ public:
 		return boostCount;
 	}
 
-	vector<double> handleCascades(Screen& screen, ReelSet& reelSet, ReelSet& offScreenReelSet, bool useDifferentReelSet, bool baseGame, int& globalMult) {
+        vector<double> handleCascades(Screen& screen, ReelSet& reelSet, ReelSet& offScreenReelSet, bool useDifferentReelSet, bool baseGame, int& globalMult, int* tumbleOut = nullptr) {
 		bool hasNewWins;
 		double initialWin = 0, tumbleWin = 0, tempWin;
 		int tumbleCount = 0;
@@ -298,8 +311,12 @@ public:
 		}
 		stats.recordFinalMult(globalMult);
 
-		return { initialWin, tumbleWin };
-	}
+                if (tumbleOut) {
+                        *tumbleOut = tumbleCount;
+                }
+
+                return { initialWin, tumbleWin };
+        }
 
 	double calculateWaysWins(Screen& screen, bool baseGame, int currentMult = 1) {
 		double totalPay = 0;

--- a/RandomUtils.h
+++ b/RandomUtils.h
@@ -6,11 +6,29 @@
 
 #include <random>
 #include <numeric>
+#include <cstdint>
 #include "RandomLogGenerator.h" // Include if you use RandomLogGenerator in these functions
 
 extern int instructionIndex; // Same for instructionIndex if it's used globally
 
 // Define a method to generate random numbers within a specified range
+inline std::mt19937& getThreadRng() {
+    thread_local std::mt19937 rng{ std::random_device{}() };
+    return rng;
+}
+
+inline std::mt19937 getThreadRngState() {
+    return getThreadRng();
+}
+
+inline void setThreadRngState(const std::mt19937& state) {
+    getThreadRng() = state;
+}
+
+inline void seedThreadRng(uint64_t seed) {
+    getThreadRng().seed(static_cast<std::mt19937::result_type>(seed));
+}
+
 inline int getRand(const std::string& mask, int range) {
     int index;
     if (logMode == REPLAY) {
@@ -29,11 +47,9 @@ inline int getRand(const std::string& mask, int range) {
         index = currentInstruction.result;
     }
     else {
-        std::random_device rd;
-        std::mt19937 gen(rd());
         std::uniform_int_distribution<> dis(0, range - 1);
-        index = dis(gen);
-        if (logMode == 1) {
+        index = dis(getThreadRng());
+        if (logMode == LOGGING) {
             RandTriple randTriple = { mask, index, range };
             RandomLogGenerator::addRandom(randTriple);
         }

--- a/Symbols.h
+++ b/Symbols.h
@@ -111,6 +111,9 @@ public:
     // Default constructor
     ReelSet() {}
 
+    const std::string& getMask() const { return mask; }
+    void setMask(const std::string& m) { mask = m; }
+
     // Calculate complete cycle
     int getCycle() const {
         int cycle = 1;

--- a/src/optimizer/ReelOptimizer.cpp
+++ b/src/optimizer/ReelOptimizer.cpp
@@ -1,0 +1,331 @@
+#include "optimizer/ReelOptimizer.h"
+
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <iomanip>
+#include <numeric>
+#include <sstream>
+
+ReelOptimizer::ReelOptimizer(GameConfig& cfg, const ReelOptParams& p)
+    : cfg_(cfg),
+      params_(p),
+      symbolStructure_(cfg.parseSymbolStructure()),
+      stats_(symbolStructure_, cfg.getRTPHeaders(), cfg.parseVar<double>("cost")),
+      cfgPtr_(&cfg, [](GameConfig*) {}),
+      instance_(std::make_unique<GameInstance>(cfgPtr_, symbolStructure_, stats_)) {}
+
+ReelSet ReelOptimizer::applySeedHeuristics(const ReelSet& in) const {
+    ReelSet out = in;
+
+    for (size_t reelIdx = 0; reelIdx < out.reels.size(); ++reelIdx) {
+        auto& symbols = out.reels[reelIdx].symbols;
+        if (symbols.empty()) {
+            continue;
+        }
+        size_t shift = reelIdx % symbols.size();
+        if (shift > 0) {
+            std::rotate(symbols.begin(), symbols.begin() + shift, symbols.end());
+        }
+    }
+
+    for (auto& reel : out.reels) {
+        auto& symbols = reel.symbols;
+        if (symbols.size() < 3) {
+            continue;
+        }
+        bool adjusted = true;
+        int guard = 0;
+        while (adjusted && guard < 3) {
+            adjusted = false;
+            size_t i = 0;
+            while (i < symbols.size()) {
+                size_t j = i + 1;
+                while (j < symbols.size() && symbols[j] == symbols[i]) {
+                    ++j;
+                }
+                size_t len = j - i;
+                if (len > 2) {
+                    size_t mid = i + len / 2;
+                    size_t swapIdx = (mid + 1) % symbols.size();
+                    size_t attempts = 0;
+                    while (attempts < symbols.size() && symbols[swapIdx] == symbols[mid]) {
+                        swapIdx = (swapIdx + 1) % symbols.size();
+                        ++attempts;
+                    }
+                    if (attempts < symbols.size()) {
+                        std::swap(symbols[mid], symbols[swapIdx]);
+                        adjusted = true;
+                        break;
+                    }
+                }
+                i = j;
+            }
+            ++guard;
+        }
+    }
+
+    auto isPremium = [](const std::string& sym) {
+        return !sym.empty() && sym[0] == 'R';
+    };
+
+    if (out.reels.size() >= 3) {
+        size_t limit = std::min({ out.reels[0].symbols.size(), out.reels[1].symbols.size(), out.reels[2].symbols.size() });
+        for (size_t idx = 0; idx < limit; ++idx) {
+            const std::string& refSymbol = out.reels[0].symbols[idx];
+            if (!isPremium(refSymbol)) {
+                continue;
+            }
+            if (out.reels[1].symbols.size() > 1 && out.reels[1].symbols[idx] == refSymbol) {
+                size_t swapIdx = (idx + 1) % out.reels[1].symbols.size();
+                size_t attempts = 0;
+                while (attempts < out.reels[1].symbols.size() && out.reels[1].symbols[swapIdx] == refSymbol) {
+                    swapIdx = (swapIdx + 1) % out.reels[1].symbols.size();
+                    ++attempts;
+                }
+                if (attempts < out.reels[1].symbols.size()) {
+                    std::swap(out.reels[1].symbols[idx], out.reels[1].symbols[swapIdx]);
+                }
+            }
+            if (out.reels[2].symbols.size() > 1 && out.reels[2].symbols[idx] == refSymbol) {
+                size_t swapIdx = (idx + 2) % out.reels[2].symbols.size();
+                size_t attempts = 0;
+                while (attempts < out.reels[2].symbols.size() && out.reels[2].symbols[swapIdx] == refSymbol) {
+                    swapIdx = (swapIdx + 1) % out.reels[2].symbols.size();
+                    ++attempts;
+                }
+                if (attempts < out.reels[2].symbols.size()) {
+                    std::swap(out.reels[2].symbols[idx], out.reels[2].symbols[swapIdx]);
+                }
+            }
+        }
+    }
+
+    return out;
+}
+
+double ReelOptimizer::fitness(const EvalMetrics& m) const {
+    double score = 0.0;
+    if (m.baseHitRate < params_.targetBaseMin) {
+        score -= params_.wBase * (params_.targetBaseMin - m.baseHitRate);
+    } else if (m.baseHitRate > params_.targetBaseMax) {
+        score -= params_.wBase * (m.baseHitRate - params_.targetBaseMax);
+    }
+    score += params_.wTumble * std::max(0.0, m.avgTumblesPerHit - params_.targetTumbles);
+    if (params_.wRtp > 0.0) {
+        if (m.rtp < params_.rtpMin) {
+            score -= params_.wRtp * (params_.rtpMin - m.rtp);
+        }
+        if (m.rtp > params_.rtpMax) {
+            score -= params_.wRtp * (m.rtp - params_.rtpMax);
+        }
+    }
+    return score;
+}
+
+ReelSet ReelOptimizer::proposeNeighbor(const ReelSet& in, std::mt19937_64& rng, std::string& moveDesc, int& reelIdx, int& a, int& b) const {
+    ReelSet candidate = in;
+    moveDesc = "noop";
+    reelIdx = -1;
+    a = -1;
+    b = -1;
+
+    if (candidate.reels.empty()) {
+        return candidate;
+    }
+
+    std::uniform_int_distribution<size_t> reelDist(0, candidate.reels.size() - 1);
+    size_t selectedReel = reelDist(rng);
+    auto& symbols = candidate.reels[selectedReel].symbols;
+    if (symbols.size() < 2) {
+        moveDesc = "rotate";
+        reelIdx = static_cast<int>(selectedReel);
+        return candidate;
+    }
+
+    std::uniform_int_distribution<int> moveDist(0, 2);
+    int moveType = moveDist(rng);
+
+    if (moveType == 0) {
+        std::uniform_int_distribution<size_t> indexDist(0, symbols.size() - 1);
+        size_t i = indexDist(rng);
+        size_t j = indexDist(rng);
+        while (j == i) {
+            j = indexDist(rng);
+        }
+        std::swap(symbols[i], symbols[j]);
+        moveDesc = "swap";
+        reelIdx = static_cast<int>(selectedReel);
+        a = static_cast<int>(i);
+        b = static_cast<int>(j);
+    } else if (moveType == 1) {
+        size_t maxShift = std::max<size_t>(1, symbols.size() / 6);
+        std::uniform_int_distribution<size_t> shiftDist(1, maxShift);
+        size_t shift = std::min<size_t>(symbols.size() - 1, shiftDist(rng));
+        std::bernoulli_distribution dir(0.5);
+        bool right = dir(rng);
+        if (right) {
+            std::rotate(symbols.rbegin(), symbols.rbegin() + static_cast<std::ptrdiff_t>(shift), symbols.rend());
+        } else {
+            std::rotate(symbols.begin(), symbols.begin() + static_cast<std::ptrdiff_t>(shift), symbols.end());
+        }
+        moveDesc = "rotate";
+        reelIdx = static_cast<int>(selectedReel);
+        a = static_cast<int>(shift);
+        b = right ? 1 : -1;
+    } else {
+        bool changed = false;
+        size_t i = 0;
+        while (i < symbols.size()) {
+            size_t j = i + 1;
+            while (j < symbols.size() && symbols[j] == symbols[i]) {
+                ++j;
+            }
+            size_t len = j - i;
+            if (len > 2) {
+                size_t mid = i + len / 2;
+                size_t swapIdx = (mid + 1) % symbols.size();
+                if (symbols[swapIdx] == symbols[mid]) {
+                    swapIdx = (swapIdx + 1) % symbols.size();
+                }
+                std::swap(symbols[mid], symbols[swapIdx]);
+                moveDesc = "break";
+                reelIdx = static_cast<int>(selectedReel);
+                a = static_cast<int>(mid);
+                b = static_cast<int>(swapIdx);
+                changed = true;
+                break;
+            }
+            i = j;
+        }
+        if (!changed) {
+            std::uniform_int_distribution<size_t> indexDist(0, symbols.size() - 1);
+            size_t iSwap = indexDist(rng);
+            size_t jSwap = indexDist(rng);
+            while (jSwap == iSwap) {
+                jSwap = indexDist(rng);
+            }
+            std::swap(symbols[iSwap], symbols[jSwap]);
+            moveDesc = "swap";
+            reelIdx = static_cast<int>(selectedReel);
+            a = static_cast<int>(iSwap);
+            b = static_cast<int>(jSwap);
+        }
+    }
+
+    return candidate;
+}
+
+bool ReelOptimizer::acceptWorse(double delta, uint32_t iter, std::mt19937_64& rng) const {
+    if (delta <= 0.0) {
+        return true;
+    }
+    const double T0 = 0.1;
+    double tau = std::max<uint32_t>(1u, params_.maxIters / 2u);
+    double temperature = T0 * std::exp(-static_cast<double>(iter) / static_cast<double>(tau));
+    if (temperature <= 1e-9) {
+        return false;
+    }
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+    double probability = std::exp(-delta / temperature);
+    return dist(rng) < probability;
+}
+
+ReelOptResult ReelOptimizer::run(const ReelSet& start) {
+    std::filesystem::create_directories("out/reelopt");
+    std::ofstream csv("out/reelopt/iterations.csv", std::ios::trunc);
+    if (csv.is_open()) {
+        csv << "iter,accept,base_hit_rate,avg_tumbles_per_hit,rtp,score,move,reel,indexA,indexB,seed\n";
+    }
+
+    ReelSet current = applySeedHeuristics(start);
+    std::mt19937_64 rng(params_.seed);
+
+    EvalMetrics currentMetrics = instance_->evaluateReelSet(current, params_.evalSpins, params_.seed);
+    double currentScore = fitness(currentMetrics);
+    ReelSet best = current;
+    EvalMetrics bestMetrics = currentMetrics;
+    double bestScore = currentScore;
+
+    uint32_t logIter = 0;
+    auto logEntry = [&](const EvalMetrics& m, bool accept, const std::string& move, int reelIdx, int ia, int ib, uint64_t seed, double score) {
+        if (!csv.is_open()) {
+            return;
+        }
+        std::ostringstream oss;
+        oss << logIter++ << "," << (accept ? 1 : 0) << ",";
+        oss << std::fixed << std::setprecision(6) << m.baseHitRate << ",";
+        oss << std::fixed << std::setprecision(6) << m.avgTumblesPerHit << ",";
+        oss << std::fixed << std::setprecision(6) << m.rtp << ",";
+        oss << std::fixed << std::setprecision(6) << score << ",";
+        oss << move << "," << reelIdx << "," << ia << "," << ib << "," << seed;
+        csv << oss.str() << "\n";
+    };
+
+    logEntry(currentMetrics, true, "seed", -1, -1, -1, params_.seed, currentScore);
+
+    uint32_t stagnant = 0;
+
+    for (uint32_t iter = 1; iter <= params_.maxIters; ++iter) {
+        std::string move;
+        int reelIdx = -1;
+        int ia = -1;
+        int ib = -1;
+        ReelSet candidate = proposeNeighbor(current, rng, move, reelIdx, ia, ib);
+        uint64_t evalSeed = params_.seed + iter;
+        EvalMetrics candMetrics = instance_->evaluateReelSet(candidate, params_.evalSpins, evalSeed);
+        double candScore = fitness(candMetrics);
+        bool accept = false;
+        if (candScore >= currentScore) {
+            accept = true;
+        } else if (acceptWorse(currentScore - candScore, iter, rng)) {
+            accept = true;
+        }
+
+        logEntry(candMetrics, accept, move, reelIdx, ia, ib, evalSeed, candScore);
+
+        if (accept) {
+            current = candidate;
+            currentMetrics = candMetrics;
+            currentScore = candScore;
+        }
+
+        if (candScore > bestScore) {
+            best = candidate;
+            bestMetrics = candMetrics;
+            bestScore = candScore;
+            stagnant = 0;
+        } else {
+            ++stagnant;
+        }
+
+        if (bestMetrics.baseHitRate >= params_.targetBaseMin && bestMetrics.baseHitRate <= params_.targetBaseMax &&
+            bestMetrics.avgTumblesPerHit >= params_.targetTumbles) {
+            break;
+        }
+
+        if (stagnant >= params_.maxNoImprove) {
+            ReelSet restart = current;
+            for (auto& reel : restart.reels) {
+                if (reel.symbols.size() > 1) {
+                    std::uniform_int_distribution<size_t> shiftDist(0, reel.symbols.size() - 1);
+                    size_t shift = shiftDist(rng);
+                    std::rotate(reel.symbols.begin(), reel.symbols.begin() + static_cast<std::ptrdiff_t>(shift), reel.symbols.end());
+                }
+            }
+            uint64_t restartSeed = params_.seed + iter + 0x10000u;
+            current = restart;
+            currentMetrics = instance_->evaluateReelSet(current, params_.evalSpins, restartSeed);
+            currentScore = fitness(currentMetrics);
+            logEntry(currentMetrics, true, "restart", -1, -1, -1, restartSeed, currentScore);
+            if (currentScore > bestScore) {
+                best = current;
+                bestMetrics = currentMetrics;
+                bestScore = currentScore;
+            }
+            stagnant = 0;
+        }
+    }
+
+    return { best, bestMetrics };
+}

--- a/src/optimizer/ReelOptimizer.h
+++ b/src/optimizer/ReelOptimizer.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <random>
+#include <memory>
+
+#include "Symbols.h"
+#include "GameInstance.h"
+#include "Stats.h"
+
+struct ReelOptParams {
+  double targetBaseMin = 1.0 / 5.5;
+  double targetBaseMax = 1.0 / 4.5;
+  double targetTumbles = 1.7;
+  double wBase = 1.0;
+  double wTumble = 1.0;
+  double wRtp = 0.25;
+  double rtpMin = 0.0;
+  double rtpMax = 10.0;
+  uint64_t evalSpins = 300000;
+  uint32_t maxIters = 2000;
+  uint32_t maxNoImprove = 150;
+  uint64_t seed = 12345;
+};
+
+struct ReelOptResult {
+  ReelSet best;
+  EvalMetrics metrics;
+};
+
+class ReelOptimizer {
+public:
+  ReelOptimizer(GameConfig& cfg, const ReelOptParams& p);
+
+  ReelOptResult run(const ReelSet& start);
+
+private:
+  double fitness(const EvalMetrics& m) const;
+  ReelSet applySeedHeuristics(const ReelSet& in) const;
+  ReelSet proposeNeighbor(const ReelSet& in, std::mt19937_64& rng, std::string& moveDesc, int& reelIdx, int& a, int& b) const;
+  bool acceptWorse(double delta, uint32_t iter, std::mt19937_64& rng) const;
+
+  GameConfig& cfg_;
+  ReelOptParams params_;
+  SymbolStructure symbolStructure_;
+  Stats stats_;
+  std::shared_ptr<GameConfig> cfgPtr_;
+  std::unique_ptr<GameInstance> instance_;
+};

--- a/tests/test_reelopt_counts.cpp
+++ b/tests/test_reelopt_counts.cpp
@@ -59,5 +59,3 @@ int main() {
     return 0;
 }
 
-#include "../GameInstance.cpp"
-#include "../src/optimizer/ReelOptimizer.cpp"

--- a/tests/test_reelopt_counts.cpp
+++ b/tests/test_reelopt_counts.cpp
@@ -1,0 +1,63 @@
+#include <cassert>
+#include <iostream>
+#include <unordered_map>
+#include <vector>
+
+#include "RandomLogGenerator.h"
+#include "GameConfig.h"
+#include "optimizer/ReelOptimizer.h"
+
+LogMode logMode = NO_LOGGING;
+
+namespace {
+std::vector<std::unordered_map<std::string, int>> countSymbols(const ReelSet& rs) {
+    std::vector<std::unordered_map<std::string, int>> counts(rs.reels.size());
+    for (size_t r = 0; r < rs.reels.size(); ++r) {
+        for (const auto& sym : rs.reels[r].symbols) {
+            counts[r][sym]++;
+        }
+    }
+    return counts;
+}
+
+ReelSet loadBase(GameConfig& cfg) {
+    try {
+        return cfg.parseReelSet("baseHigh");
+    } catch (...) {
+    }
+    try {
+        return cfg.parseReelSet("base");
+    } catch (...) {
+    }
+    return cfg.parseReelSet("baseLow");
+}
+}
+
+int main() {
+    GameConfig cfg("config.json");
+    ReelSet original = loadBase(cfg);
+
+    ReelOptParams params;
+    params.evalSpins = 50000;
+    params.maxIters = 1;
+    params.maxNoImprove = 1;
+    params.seed = 1337;
+
+    ReelOptimizer optimizer(cfg, params);
+    ReelOptResult result = optimizer.run(original);
+
+    auto originalCounts = countSymbols(original);
+    auto optimizedCounts = countSymbols(result.best);
+    assert(originalCounts.size() == optimizedCounts.size());
+    for (size_t i = 0; i < originalCounts.size(); ++i) {
+        assert(originalCounts[i] == optimizedCounts[i]);
+    }
+
+    std::cout << "Test metrics: base=" << result.metrics.baseHitRate
+              << " tumbles=" << result.metrics.avgTumblesPerHit
+              << " rtp=" << result.metrics.rtp << "\n";
+    return 0;
+}
+
+#include "../GameInstance.cpp"
+#include "../src/optimizer/ReelOptimizer.cpp"

--- a/tools/reelopt/main.cpp
+++ b/tools/reelopt/main.cpp
@@ -1,0 +1,109 @@
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+#include "GameConfig.h"
+#include "optimizer/ReelOptimizer.h"
+#include "json.hpp"
+
+namespace {
+ReelSet loadBaseReelSet(GameConfig& cfg) {
+    try {
+        return cfg.parseReelSet("baseHigh");
+    } catch (const std::exception&) {
+    }
+    try {
+        return cfg.parseReelSet("base");
+    } catch (const std::exception&) {
+    }
+    return cfg.parseReelSet("baseLow");
+}
+
+void applyOverrides(const nlohmann::json& j, ReelOptParams& params) {
+    if (j.contains("evalSpins")) params.evalSpins = j["evalSpins"].get<uint64_t>();
+    if (j.contains("maxIters")) params.maxIters = j["maxIters"].get<uint32_t>();
+    if (j.contains("maxNoImprove")) params.maxNoImprove = j["maxNoImprove"].get<uint32_t>();
+    if (j.contains("seed")) params.seed = j["seed"].get<uint64_t>();
+    if (j.contains("targetBaseMin")) params.targetBaseMin = j["targetBaseMin"].get<double>();
+    if (j.contains("targetBaseMax")) params.targetBaseMax = j["targetBaseMax"].get<double>();
+    if (j.contains("targetTumbles")) params.targetTumbles = j["targetTumbles"].get<double>();
+    if (j.contains("wBase")) params.wBase = j["wBase"].get<double>();
+    if (j.contains("wTumble")) params.wTumble = j["wTumble"].get<double>();
+    if (j.contains("wRtp")) params.wRtp = j["wRtp"].get<double>();
+    if (j.contains("rtpMin")) params.rtpMin = j["rtpMin"].get<double>();
+    if (j.contains("rtpMax")) params.rtpMax = j["rtpMax"].get<double>();
+}
+
+void printUsage() {
+    std::cout << "Usage: reelopt [--config path] [--game config.json] [--spins N] [--seed S]\n";
+}
+}
+
+int main(int argc, char** argv) {
+    std::string toolConfigPath = "tools/reelopt/reelopt_config.json";
+    std::string gameConfigPath = "config.json";
+    std::optional<uint64_t> spinsOverride;
+    std::optional<uint64_t> seedOverride;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--config" && i + 1 < argc) {
+            toolConfigPath = argv[++i];
+        } else if (arg == "--game" && i + 1 < argc) {
+            gameConfigPath = argv[++i];
+        } else if (arg == "--spins" && i + 1 < argc) {
+            spinsOverride = static_cast<uint64_t>(std::stoull(argv[++i]));
+        } else if (arg == "--seed" && i + 1 < argc) {
+            seedOverride = static_cast<uint64_t>(std::stoull(argv[++i]));
+        } else if (arg == "--help") {
+            printUsage();
+            return 0;
+        } else {
+            std::cerr << "Unknown argument: " << arg << "\n";
+            printUsage();
+            return 1;
+        }
+    }
+
+    try {
+        GameConfig cfg(gameConfigPath);
+        ReelOptParams params;
+
+        std::ifstream cfgStream(toolConfigPath);
+        if (cfgStream.is_open()) {
+            nlohmann::json j;
+            cfgStream >> j;
+            applyOverrides(j, params);
+        }
+        if (spinsOverride) {
+            params.evalSpins = *spinsOverride;
+        }
+        if (seedOverride) {
+            params.seed = *seedOverride;
+        }
+
+        ReelSet start = loadBaseReelSet(cfg);
+        ReelOptimizer optimizer(cfg, params);
+        ReelOptResult result = optimizer.run(start);
+
+        std::filesystem::create_directories("out/reelopt");
+        cfg.writeReelSetToFile(result.best, "out/reelopt/reelset_final.json", "optimized_base");
+
+        std::cout << std::fixed << std::setprecision(4)
+                  << "base=" << result.metrics.baseHitRate
+                  << " tumbles=" << result.metrics.avgTumblesPerHit
+                  << " rtp=" << result.metrics.rtp << "\n";
+
+        bool success = result.metrics.baseHitRate >= params.targetBaseMin &&
+                        result.metrics.baseHitRate <= params.targetBaseMax &&
+                        result.metrics.avgTumblesPerHit >= params.targetTumbles;
+        return success ? 0 : 2;
+    } catch (const std::exception& ex) {
+        std::cerr << "Error: " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/tools/reelopt/reelopt_config.json
+++ b/tools/reelopt/reelopt_config.json
@@ -1,0 +1,14 @@
+{
+  "evalSpins": 300000,
+  "maxIters": 2000,
+  "maxNoImprove": 150,
+  "seed": 12345,
+  "targetBaseMin": 0.1818,
+  "targetBaseMax": 0.2222,
+  "targetTumbles": 1.7,
+  "wBase": 1.0,
+  "wTumble": 1.0,
+  "wRtp": 0.25,
+  "rtpMin": 0.0,
+  "rtpMax": 10.0
+}


### PR DESCRIPTION
## Summary
- add evaluation hooks and RNG control to evaluate reel sets with deterministic seeds
- implement a simulated annealing reel optimizer module and a CLI driver with config template
- expose JSON helpers for reel sets and add invariant test covering symbol counts

## Testing
- ./test_reelopt

------
https://chatgpt.com/codex/tasks/task_e_68da3a5e6a448324a8d4061be851491a